### PR TITLE
Pull upstream changes

### DIFF
--- a/lib/rack/ssl.rb
+++ b/lib/rack/ssl.rb
@@ -69,7 +69,13 @@ module Rack
 
       def flag_cookies_as_secure!(headers)
         if cookies = headers['Set-Cookie']
-          headers['Set-Cookie'] = cookies.split("\n").map { |cookie|
+          # Rack 1.1's set_cookie_header! will sometimes wrap
+          # Set-Cookie in an array
+          unless cookies.respond_to?(:to_ary)
+            cookies = cookies.split("\n")
+          end
+
+          headers['Set-Cookie'] = cookies.map { |cookie|
             if cookie !~ /; secure(;|$)/
               "#{cookie}; secure"
             else

--- a/lib/rack/ssl.rb
+++ b/lib/rack/ssl.rb
@@ -18,7 +18,6 @@ module Rack
 
       @exclude = options[:exclude]
       @host    = options[:host]
-      @port    = options[:port]
     end
 
     def call(env)
@@ -51,7 +50,6 @@ module Rack
         url        = URI(req.url)
         url.scheme = "https"
         url.host   = @host if @host
-        url.port   = @port if @port
         headers    = hsts_headers.merge('Content-Type' => 'text/html',
                                         'Location'     => url.to_s)
 

--- a/rack-ssl.gemspec
+++ b/rack-ssl.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name      = 'rack-ssl'
-  s.version   = '1.3.2'
-  s.date      = '2011-03-24'
+  s.version   = '1.3.3'
+  s.date      = '2013-01-29'
 
   s.homepage    = "https://github.com/josh/rack-ssl"
   s.summary     = "Force SSL/TLS in your app."

--- a/rack-ssl.gemspec
+++ b/rack-ssl.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name      = 'rack-ssl'
-  s.version   = '1.4.0'
-  s.date      = '2014-03-17'
+  s.version   = '1.4.1'
+  s.date      = '2014-03-23'
 
   s.homepage    = "https://github.com/josh/rack-ssl"
   s.summary     = "Force SSL/TLS in your app."

--- a/rack-ssl.gemspec
+++ b/rack-ssl.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name      = 'rack-ssl'
-  s.version   = '1.3.1'
-  s.date      = '2011-02-16'
+  s.version   = '1.3.2'
+  s.date      = '2011-03-24'
 
   s.homepage    = "https://github.com/josh/rack-ssl"
   s.summary     = "Force SSL/TLS in your app."

--- a/rack-ssl.gemspec
+++ b/rack-ssl.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name      = 'rack-ssl'
-  s.version   = '1.3.3'
-  s.date      = '2013-01-29'
+  s.version   = '1.4.0'
+  s.date      = '2014-03-17'
 
   s.homepage    = "https://github.com/josh/rack-ssl"
   s.summary     = "Force SSL/TLS in your app."

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -124,20 +124,6 @@ class TestSSL < Test::Unit::TestCase
       last_response.headers['Location']
   end
 
-  def test_redirect_to_port
-    self.app = Rack::SSL.new(default_app, :port => 8443)
-    get "http://example.org/path?key=value"
-    assert_equal "https://example.org:8443/path?key=value",
-      last_response.headers['Location']
-  end
-
-  def test_redirect_to_host_and_port
-    self.app = Rack::SSL.new(default_app, :host => "ssl.example.org", :port => 8443)
-    get "http://example.org/path?key=value"
-    assert_equal "https://ssl.example.org:8443/path?key=value",
-      last_response.headers['Location']
-  end
-
   def test_redirect_to_secure_host_when_on_subdomain
     self.app = Rack::SSL.new(default_app, :host => "ssl.example.org")
     get "http://ssl.example.org/path?key=value"


### PR DESCRIPTION
Our version of rack-ssl contains security vulnerability CVE-2014-2538. Updating to rack-ssl 1.4.0 should fix that and it seems upstream has done that.